### PR TITLE
Refactor/keyword component

### DIFF
--- a/src/components/CampaignStatistics/StatGraph.jsx
+++ b/src/components/CampaignStatistics/StatGraph.jsx
@@ -95,6 +95,8 @@ const StatGraph = ({ search, nonSearch, startDate, endDate }) => {
                     text: 'Ad Sales',
                 },
                 stacked: true, // y 축 스택 설정
+                min: 0, // 최소값 설정
+                max: Math.max(...adCostData, ...searchData, ...nonSearchData) * 1.5, // 최대값 설정 (최대 데이터의 1.5배)
             },
             'y-roas': {
                 title: {
@@ -104,6 +106,9 @@ const StatGraph = ({ search, nonSearch, startDate, endDate }) => {
                 position: 'right', // y축 위치 설정
                 ticks: {
                     beginAtZero: true,
+                },
+                grid: {
+                    display: false, // Y축의 그리드 선을 보이지 않게 설정
                 },
             },
         },

--- a/src/components/CampaignStatistics/StatGraphTable.jsx
+++ b/src/components/CampaignStatistics/StatGraphTable.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import '../../styles/campaignStats/StatTable.css'
 const StatGraphTable = ({ search, nonSearch, startDate, endDate }) => {
     // 날짜를 배열로 생성
     const dateLabels = [];
@@ -35,9 +35,19 @@ const StatGraphTable = ({ search, nonSearch, startDate, endDate }) => {
         return clicks > 0 ? ((sales / clicks) * 100).toFixed(2) : 0; // 전환율 계산
     });
 
+    const formatNumber = (num) => {
+        if (num >= 10000) {
+            return (num / 10000).toFixed(1) + '만'; // 1만, 2.1만 형식
+        } else if (num >= 1000) {
+            return (num / 1000).toFixed(0) + '천'; // 1천, 2천 형식
+        }
+        return num.toString(); // 천 이하의 숫자는 그대로 반환
+    };
+
+
     return (
         <div>
-            <div style={{ overflowX: 'auto', padding: '10px' }}>
+            <div style={{ overflowX: 'auto', padding: '0px' }}>
                 <table style={{ fontSize: '8px', width: '100%', borderCollapse: 'collapse' }}>
                     <thead>
                         <tr>
@@ -50,7 +60,7 @@ const StatGraphTable = ({ search, nonSearch, startDate, endDate }) => {
                     <tbody>
                         {/* Click Rate Row */}
                         <tr>
-                            <td style={{ padding: '5px', border: '1px solid #ddd' }}>클릭율 (%)</td>
+                            <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>클릭율 (%)</td>
                             {clickRateData.map((rate, index) => (
                                 <td key={index} style={{ padding: '5px', border: '1px solid #ddd' }}>{rate}</td>
                             ))}
@@ -58,15 +68,17 @@ const StatGraphTable = ({ search, nonSearch, startDate, endDate }) => {
 
                         {/* Impressions Row */}
                         <tr>
-                            <td style={{ padding: '5px', border: '1px solid #ddd' }}>노출 수</td>
+                            <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>노출 수</td>
                             {impressionData.map((impression, index) => (
-                                <td key={index} style={{ padding: '5px', border: '1px solid #ddd' }}>{impression}</td>
+                                <td key={index} style={{ padding: '5px', border: '1px solid #ddd', whiteSpace: 'nowrap' }}>
+                                    {formatNumber(impression)} {/* 포맷된 숫자 표시 */}
+                                </td>
                             ))}
                         </tr>
 
                         {/* Clicks Row */}
                         <tr>
-                            <td style={{ padding: '5px', border: '1px solid #ddd' }}>클릭 수</td>
+                            <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>클릭 수</td>
                             {clicksData.map((click, index) => (
                                 <td key={index} style={{ padding: '5px', border: '1px solid #ddd' }}>{click}</td>
                             ))}
@@ -74,7 +86,7 @@ const StatGraphTable = ({ search, nonSearch, startDate, endDate }) => {
 
                         {/* CVR Row */}
                         <tr>
-                            <td style={{ padding: '5px', border: '1px solid #ddd' }}>전환율 (%)</td>
+                            <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>전환율 (%)</td>
                             {cvrData.map((cvr, index) => (
                                 <td key={index} style={{ padding: '5px', border: '1px solid #ddd' }}>{cvr}</td>
                             ))}
@@ -82,7 +94,7 @@ const StatGraphTable = ({ search, nonSearch, startDate, endDate }) => {
 
                         {/* Total Sales Row */}
                         <tr>
-                            <td style={{ padding: '5px', border: '1px solid #ddd' }}>Total Sales</td>
+                            <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>Total Sales</td>
                             {totalSalesData.map((sales, index) => (
                                 <td key={index} style={{ padding: '5px', border: '1px solid #ddd' }}>{sales}</td>
                             ))}

--- a/src/components/KeyTotalComponent.jsx
+++ b/src/components/KeyTotalComponent.jsx
@@ -196,7 +196,35 @@ const KeytotalComponent = ({ campaignId, startDate, endDate }) => {
     }
 
     const handleDownload = () => {
-        handleRegisterExclusionKeywords();
+        if (exclusionKeywords.length === 0) {
+            alert("복사할 제외 키드가 없습니다.");
+            return;
+        }
+        // console.log(exclusionKeywords);
+        const keywordsToCopy = exclusionKeywords.map(keyword => keyword.exclusionKeyword).join('\n'); // 제외 키워드의 값을 줄바꿈으로 연결
+        navigator.clipboard.writeText(keywordsToCopy) // 클립보드에 복사
+            .then(() => {
+                alert("제외 키워드가 클립보드에 복사되었습니다.");
+            })
+            .catch((error) => {
+                console.error("복사 실패:", error);
+            });
+    };
+
+    const handleDownloadBid = () => {
+        if (bidKeywords.length === 0) {
+            alert("복사할 입찰가 없습니다.");
+            return;
+        }
+        // console.log(exclusionKeywords);
+        const keywordsToCopy = bidKeywords.map(keyword => `${keyword.keyKeyword}\t${keyword.bid}`).join('\n'); // 제외 키워드와 가격을 탭으로 구분하여 같은 가로줄로 연결
+        navigator.clipboard.writeText(keywordsToCopy) // 클립보드에 복사
+            .then(() => {
+                alert("입찰가가가 클립보드에 복사되었습니다.");
+            })
+            .catch((error) => {
+                console.error("복사 실패:", error);
+            });
     };
 
     return (
@@ -243,7 +271,7 @@ const KeytotalComponent = ({ campaignId, startDate, endDate }) => {
                     {activeComponent === "bid" && (
                         <>
                             <button className="keyword-button primary-button" onClick={handleUpdateKeywordBids}>수정</button>
-                            <button className="keyword-button primary-button" onClick={handleDownload}>복사</button>
+                            <button className="keyword-button primary-button" onClick={handleDownloadBid}>복사</button>
                             <button className="keyword-button primary-button" onClick={handleDeleteKeywordBids}>삭제</button>
                         </>
                     )}

--- a/src/components/KeywordBidComponent.jsx
+++ b/src/components/KeywordBidComponent.jsx
@@ -95,15 +95,15 @@ const KeywordComponent = ({ selectedKeywords, setSelectedKeywords, keywords, loa
                     {filteredKeywords.map((item, index) => (
                         <tr key={index}>
                             <td>{item.keyKeyword}</td>
-                            <td>{item.keyImpressions}</td>
-                            <td>{item.keyClicks}</td>
-                            <td>{item.keyClickRate}%</td>
-                            <td>{item.keyTotalSales}</td>
-                            <td>{item.keyCvr}%</td>
-                            <td>{item.keyAdsales}</td>
-                            <td>{item.keyAdcost}</td>
-                            <td>{item.keyRoas}%</td>
-                            <td>{item.keyCpc}</td>
+                            <td>{item.keyImpressions.toLocaleString()}</td> {/* 천 단위 구분 기호 추가 */}
+                            <td>{item.keyClicks.toLocaleString()}</td> {/* 천 단위 구분 기호 추가 */}
+                            <td>{item.keyClickRate.toLocaleString()}%</td> {/* 천 단위 구분 기호 추가 */}
+                            <td>{item.keyTotalSales.toLocaleString()}</td> {/* 천 단위 구분 기호 추가 */}
+                            <td>{item.keyCvr.toLocaleString()}%</td> {/* 천 단위 구분 기호 추가 */}
+                            <td>{item.keyAdsales.toLocaleString()}원</td> {/* 천 단위 구분 기호 추가 */}
+                            <td>{item.keyAdcost.toLocaleString()}원</td> {/* 천 단위 구분 기호 추가 */}
+                            <td>{item.keyRoas.toLocaleString()}%</td> {/* 천 단위 구분 기호 추가 */}
+                            <td>{item.keyCpc.toLocaleString()}원</td> {/* 천 단위 구분 기호 추가 */}
                             <td>
                                 <input
                                     type="number" // 숫자 입력 필드로 변경
@@ -115,7 +115,7 @@ const KeywordComponent = ({ selectedKeywords, setSelectedKeywords, keywords, loa
                                         boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)', // 그림자 추가
                                         transition: 'border-color 0.3s, box-shadow 0.3s', // 부드러운 변화 효과
                                     }}
-                                    value={editableBids[item.keyKeyword] !== undefined ? editableBids[item.keyKeyword] : item.keyCpc} // 사용자가 입력한 값 또는 기본값 사용
+                                    value={editableBids[item.keyKeyword] !== undefined ? editableBids[item.keyKeyword] : Math.round(item.keyCpc)} // 사용자가 입력한 값 또는 기본값 사용
                                     onChange={(e) => handleBidChange(item.keyKeyword, e.target.value)} // 입력값 변경 시 상태 업데이트
                                 />
                             </td>

--- a/src/components/KeywordComponent.jsx
+++ b/src/components/KeywordComponent.jsx
@@ -136,47 +136,47 @@ const KeywordComponent = ({ campaignId, startDate, endDate, selectedKeywords, se
                             <td style={{
                                 color: item.keyExcludeFlag ? '#d3264f' : 'inherit',
                             }}>
-                                {item.keyImpressions}
+                                {item.keyImpressions.toLocaleString()} {/* 천 단위 구분 기호 추가 */}
                             </td>
                             <td style={{
                                 color: item.keyExcludeFlag ? '#d3264f' : 'inherit',
                             }}>
-                                {item.keyClicks}
+                                {item.keyClicks.toLocaleString()} {/* 천 단위 구분 기호 추가 */}
                             </td>
                             <td style={{
                                 color: item.keyExcludeFlag ? '#d3264f' : 'inherit',
                             }}>
-                                {item.keyClickRate}%
+                                {item.keyClickRate.toLocaleString()}% {/* 천 단위 구분 기호 추가 */}
                             </td>
                             <td style={{
                                 color: item.keyExcludeFlag ? '#d3264f' : 'inherit',
                             }}>
-                                {item.keyTotalSales}
+                                {item.keyTotalSales.toLocaleString()} {/* 천 단위 구분 기호 추가 */}
                             </td>
                             <td style={{
                                 color: item.keyExcludeFlag ? '#d3264f' : 'inherit',
                             }}>
-                                {item.keyCvr}%
+                                {item.keyCvr.toLocaleString()}% {/* 천 단위 구분 기호 추가 */}
                             </td>
                             <td style={{
                                 color: item.keyExcludeFlag ? '#d3264f' : 'inherit',
                             }}>
-                                {item.keyCpc}
+                                {item.keyCpc.toLocaleString()}원 {/* 천 단위 구분 기호 추가 */}
                             </td>
                             <td style={{
                                 color: item.keyExcludeFlag ? '#d3264f' : 'inherit',
                             }}>
-                                {item.keyAdcost}
+                                {item.keyAdcost.toLocaleString()}원 {/* 천 단위 구분 기호 추가 */}
                             </td>
                             <td style={{
                                 color: item.keyExcludeFlag ? '#d3264f' : 'inherit',
                             }}>
-                                {item.keyAdsales}
+                                {item.keyAdsales.toLocaleString()}원 {/* 천 단위 구분 기호 추가 */}
                             </td>
                             <td style={{
                                 color: item.keyExcludeFlag ? '#d3264f' : 'inherit',
                             }}>
-                                {item.keyRoas}%
+                                {item.keyRoas.toLocaleString()}% {/* 천 단위 구분 기호 추가 */}
                             </td>
                             <td>
                                 <input

--- a/src/components/Totalsearchbar.jsx
+++ b/src/components/Totalsearchbar.jsx
@@ -8,7 +8,7 @@ import "../styles/TabComponent.css";
 import { useParams } from "react-router-dom";
 
 const Totalsearchbar = ({ title }) => {
-    const [activeTab, setActiveTab] = useState("campaign");
+    const [activeTab, setActiveTab] = useState("stats");
     const [startDate, setStartDate] = useState(new Date());
     const { campaignId } = useParams();
     const [endDate, setEndDate] = useState(new Date());

--- a/src/styles/campaignStats/StatTable.css
+++ b/src/styles/campaignStats/StatTable.css
@@ -1,0 +1,14 @@
+/* styles.css 또는 해당 컴포넌트의 CSS 파일에 추가 */
+.sticky-cell {
+    position: sticky;
+    left: 0;
+    /* 왼쪽에 고정 */
+    background-color: white;
+    /* 배경색 설정 */
+    z-index: 0;
+    /* 다른 요소와 겹치지 않도록 설정 */
+    white-space: nowrap;
+    /* 줄바꿈 방지 */
+    border-right: 1px solid #ddd;
+    /* 오른쪽 경계 추가 (선택 사항) */
+}


### PR DESCRIPTION
엥 양식이 어디갔지?

1. keyword 페이지 관련.
- 제외 및 수동입찰가 복사 버튼 기능 추가
- 각 키워드 테이블 숫자 데이터에 쉼표 처리

2. 기본 통계
- 그래프 y축을 최대 데이터 수치 1.5 배로 설정하여 그래프의 가시성 높임
- 그래프 아래 테이블 맨 첫줄 td 고정.
- 캠패인 클릭 시 기본 통계 컴포넌트가 랜더링 되도록 설정.
