### PR TITLE
Fix/design

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,21 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-            name="description"
-            content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -24,12 +22,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+  <title>Grouup</title>
 </head>
+
 <body>
-<noscript>You need to enable JavaScript to run this app.</noscript>
-<div id="root"></div>
-<!--
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
   This HTML file is a template.
   If you open it directly in the browser, you will see an empty page.
 
@@ -40,4 +39,5 @@
   To create a production bundle, use `npm run build` or `yarn build`.
 -->
 </body>
+
 </html>

--- a/src/components/Margin/MarginCalculatorForm.jsx
+++ b/src/components/Margin/MarginCalculatorForm.jsx
@@ -79,7 +79,6 @@ const MarginCalculatorForm = ({ campaigns }) => {
     };
 
     const handleCalculate = () => {
-        console.log("버튼 클릭됨");
         const updatedOptions = [...calculatedOptions];
 
         selectedOptions.forEach(index => {
@@ -89,13 +88,11 @@ const MarginCalculatorForm = ({ campaigns }) => {
             }
 
             const option = updatedOptions[index];
-            console.log(option);
 
             // 필요한 값이 존재하는지 확인
             if (option && option.mfcSalePrice && option.mfcTotalPrice && option.mfcCostPrice) {
                 const margin = Math.round(option.mfcSalePrice - (1.1 * option.mfcTotalPrice) - option.mfcCostPrice) || 0;
                 const zeroROAS = margin !== 0 ? ((option.mfcSalePrice / margin) * 1.1 * 100).toFixed(2) : "0.00";
-                console.log(margin, zeroROAS);
 
                 updatedOptions[index] = {
                     ...option,

--- a/src/components/Margin/MarginCalulatorComponets/ActionButtons.jsx
+++ b/src/components/Margin/MarginCalulatorComponets/ActionButtons.jsx
@@ -84,13 +84,14 @@ const ActionButtons = ({ selectedOptions, options, campaignId, handleCalculate }
         // API 호출을 통한 업데이트
         try {
             const response = await updateExecutionAboutCampaign(mfcRequestDtos);
-            console.log("Save response:", response);
 
             if (response.data && response.data.failedProductNames && response.data.failedProductNames.length > 0) {
                 alert(`저장 실패한 상품명: ${response.data.failedProductNames.join(", ")}`);
             } else {
                 alert("저장이 성공적으로 완료되었습니다.");
                 setErrorMessage(""); // 성공 시 에러 메시지 초기화
+                localStorage.setItem("isFirstVisit", "true");
+                window.location.reload();
             }
         } catch (error) {
             console.error("Error saving data:", error);

--- a/src/components/Margin/MarginCalulatorComponets/ActionButtons.jsx
+++ b/src/components/Margin/MarginCalulatorComponets/ActionButtons.jsx
@@ -56,7 +56,6 @@ const ActionButtons = ({ selectedOptions, options, campaignId, handleCalculate }
 
         // 마진과 제로 ROAS 계산 후 업데이트
         const updatedOptions = [...options]; // 원본 옵션 복사
-
         // 수정 하는경우, 앞에 3개 수정 후 계산하기 안 누르고 저장시, 바뀐 값으로 저장
         selectedOptions.forEach(index => {
             const option = updatedOptions[index];
@@ -69,11 +68,11 @@ const ActionButtons = ({ selectedOptions, options, campaignId, handleCalculate }
                 option.mfcZeroRoas = parseFloat(zeroROAS);
             }
         });
-
         // 선택된 옵션만 포함하도록 수정
         const mfcRequestDtos = {
             campaignId: campaignId,
             data: selectedOptions.map(index => ({
+                mfcId: updatedOptions[index].id,
                 mfcProductName: updatedOptions[index].mfcProductName,
                 mfcSalePrice: updatedOptions[index].mfcSalePrice,
                 mfcTotalPrice: updatedOptions[index].mfcTotalPrice,
@@ -82,7 +81,6 @@ const ActionButtons = ({ selectedOptions, options, campaignId, handleCalculate }
                 mfcZeroRoas: updatedOptions[index].mfcZeroRoas,
             })),
         };
-
         // API 호출을 통한 업데이트
         try {
             const response = await updateExecutionAboutCampaign(mfcRequestDtos);

--- a/src/components/Margin/MarginResultModal.jsx
+++ b/src/components/Margin/MarginResultModal.jsx
@@ -100,6 +100,8 @@ const MarginResultModal = ({ isOpen, onClose, campaignId }) => {
         try {
             await marginUpdatesByPeriod(mfcRequestWithDatesDto);
             alert("선택된 데이터가 저장되었습니다!");
+            localStorage.setItem("isFirstVisit", "true");
+            window.location.reload();
         } catch (error) {
             console.error("저장 중 오류 발생:", error);
             alert("저장 중 오류가 발생했습니다.");

--- a/src/components/Margin/MarginTabNavigation.jsx
+++ b/src/components/Margin/MarginTabNavigation.jsx
@@ -13,7 +13,6 @@ const MarginTabNavigation = () => {
     const [endDate, setEndDate] = useState(new Date());
     const [monthYear, setMonthYear] = useState(new Date()); // 월 선택 상태 추가
 
-
     const handleComponentChange = (component) => {
         setActiveComponent(component);
     };
@@ -41,7 +40,6 @@ const MarginTabNavigation = () => {
         return { startOfMonth, endOfMonth };
     };
 
-
     // 월 선택 시 시작일과 끝일 업데이트
     const handleMonthYearChange = (date) => {
         setMonthYear(date);
@@ -49,6 +47,7 @@ const MarginTabNavigation = () => {
         setStartDate(startOfMonth);
         setEndDate(endOfMonth);
     };
+
     return (
         <div className="main-content">
             <div className="min-h-screen bg-gray-100">
@@ -56,10 +55,8 @@ const MarginTabNavigation = () => {
                     <main className="container mx-auto p-6">
                         <div className="flex items-center justify-between">
                             <TabNavigation onComponentChange={handleComponentChange} />
-                            {/* activeComponent가 "MarginCalculatorResult"일 때만 DatePicker 표시 */}
                             {activeComponent === "MarginCalculatorResult" && (
                                 <div className="date-picker-container">
-                                    {/* 년월 선택기 */}
                                     <div className="date-picker-group month-picker-group">
                                         <DatePicker
                                             selected={monthYear}
@@ -100,6 +97,7 @@ const MarginTabNavigation = () => {
                                     campaigns={campaign}
                                     startDate={startDate.toISOString().split("T")[0]}
                                     endDate={endDate.toISOString().split("T")[0]}
+                                    isActive={activeComponent === "MarginCalculatorResult"} // 활성화 여부 전달
                                 />
                             )}
                         </div>

--- a/src/pages/KakaoLoginCallback.js
+++ b/src/pages/KakaoLoginCallback.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 
 function KakaoLoginCallback() {
     useEffect(() => {
@@ -8,7 +8,7 @@ function KakaoLoginCallback() {
         if (token) {
             localStorage.clear();
             localStorage.setItem("accessToken", token);
-
+            localStorage.setItem("isFirstVisit", "true"); // 이후에는 API 호출하지 않도록 설정
             // 저장된 토큰 확인
             console.log("Token saved in localStorage:", localStorage.getItem("accessToken"));
 

--- a/src/styles/Sidebar.css
+++ b/src/styles/Sidebar.css
@@ -47,10 +47,10 @@
   cursor: pointer;
 }
 
-.menu-item-content:hover:not(.active) {
+/* .menu-item-content:hover:not(.active) {
   background-color: #9da7d3;
   color: white;
-}
+} */
 
 .menu-item-content.active {
   background-color: #5C62B8;

--- a/src/styles/margin/MarginResultModal.css
+++ b/src/styles/margin/MarginResultModal.css
@@ -38,6 +38,7 @@
     /* 버튼과 날짜 선택기를 양쪽 끝으로 배치 */
     padding-left: 20px;
     /* 왼쪽 여백 추가 */
+    gap: 10px;
 }
 
 .date-picker-group {

--- a/src/utils/tokenManager.js
+++ b/src/utils/tokenManager.js
@@ -1,5 +1,5 @@
 const TOKEN_KEY = 'accessToken';
-
+const IS_FIRST_VIST = 'isFirstVisit'
 // 토큰 저장
 export const setToken = (token) => {
   localStorage.setItem(TOKEN_KEY, token);
@@ -13,4 +13,5 @@ export const getToken = () => {
 // 토큰 삭제
 export const removeToken = () => {
   localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(IS_FIRST_VIST)
 };


### PR DESCRIPTION
처음에 로그인을 하였을때 

로컬 스토리지에 
![스크린샷 2025-02-13 오후 4 08 01](https://github.com/user-attachments/assets/be630b0a-10b9-4f39-ba75-47e374a7444f)

다음과 같이 isVisited true를 넣어줍니다.
### **false로 바뀌는경우**
마진 결과 페이지  처음 방문한경우
![스크린샷 2025-02-13 오후 4 09 53](https://github.com/user-attachments/assets/e02e3e51-46e0-40ae-9dd4-b18fc5d56db3)
해당하는 월의 시작부터 끝날까지 모든 캠페인의 일별 전체 합산 금액을 계산합니다.

### **true로 바뀌는경우**
1. 마진 계산식 입력 페이지에서 새로운 옵션이 추가되었을때.
2. 마진 결과 보기에서 옵션 가격 변경했을경우

true 로 바뀌는 경우에서는 많아봤자 1, 2개 일거로 예상되는데 false로 바꿔서 관리하는 경우 모든 캠페인을 건드려 가져옵니다.
바뀌는 것만 업데이트 칠 수 있는 로직 고민해보겠습니다.

