### PR TITLE
Refactor/keyword component 캠패인 탭 관련 디자인 수정 사항 및 추가 사항입니다.

### DIFF
--- a/src/components/CampaignStatistics/StatGraph.jsx
+++ b/src/components/CampaignStatistics/StatGraph.jsx
@@ -34,7 +34,6 @@ const StatGraph = ({ search, nonSearch, startDate, endDate }) => {
         return totalCost > 0 ? (totalRevenue / totalCost) * 100 : 0; // 비용이 0일 경우 0을 반환
     });
 
-    // 데이터 준비
     const data = {
         labels: dateLabels,
         datasets: [
@@ -43,12 +42,14 @@ const StatGraph = ({ search, nonSearch, startDate, endDate }) => {
                 data: searchData,
                 backgroundColor: 'rgba(54, 162, 235, 0.6)', // Search 색상 (파랑)
                 stack: 'Stack 0', // 스택 설정
+                order: 3, // 막대 그래프 우선
             },
             {
                 label: '비검색',
                 data: nonSearchData,
                 backgroundColor: 'rgba(255, 159, 64, 0.6)', // Non-Search 색상 (주황)
                 stack: 'Stack 0', // 스택 설정
+                order: 3, // 막대 그래프 우선
             },
             {
                 label: '광고비',
@@ -56,7 +57,8 @@ const StatGraph = ({ search, nonSearch, startDate, endDate }) => {
                 borderColor: 'rgb(0, 123, 255)', // Ad Cost 선 색상 (짙은 파랑)
                 backgroundColor: 'rgba(0, 123, 255, 0.3)', // Ad Cost 색상 (옅은 파랑)
                 type: 'line', // 선 그래프로 표시
-                fill: true, // 선 그래프 안 채우기
+                fill: false, // 선 그래프 안 채우기
+                order: 1, // 선 그래프를 막대 위에 표시
             },
             {
                 label: 'ROAS',
@@ -64,11 +66,13 @@ const StatGraph = ({ search, nonSearch, startDate, endDate }) => {
                 borderColor: 'rgb(255, 99, 132)', // ROAS 선 색상 (빨강)
                 backgroundColor: 'rgba(255, 99, 132, 0.3)', // ROAS 색상 (옅은 빨강)
                 type: 'line', // 선 그래프로 표시
-                fill: true, // 선 그래프 안 채우기
+                fill: false, // 선 그래프 안 채우기
                 yAxisID: 'y-roas', // ROAS 데이터의 y축 ID
+                order: 1, // ROAS 선 그래프를 가장 위에 표시
             },
         ],
     };
+
 
     // 옵션 설정
     const options = {

--- a/src/components/CampaignStatistics/StatGraph2.jsx
+++ b/src/components/CampaignStatistics/StatGraph2.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, LineElement } from 'chart.js';
+
+// Chart.js 등록
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, LineElement);
+
+const StatGraph2 = ({ search, nonSearch, startDate, endDate }) => {
+    // 날짜를 배열로 생성
+    const dateLabels = [];
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+
+    // 날짜를 추가
+    for (let dt = start; dt <= end; dt.setDate(dt.getDate() + 1)) {
+        dateLabels.push(dt.toISOString().split('T')[0]); // 'YYYY-MM-DD' 형식으로 변환
+    }
+
+    // search와 nonSearch 데이터를 각각의 배열로 변환
+    const searchImpressionData = dateLabels.map(date => (search[date] ? search[date].keyClicks : 0));
+    const searchKeyTotalSalesData = dateLabels.map(date => (search[date] ? search[date].keyTotalSales : 0));
+    const nonsearchImpressionData = dateLabels.map(date => (nonSearch[date] ? nonSearch[date].keyClicks : 0));
+    const nonsearchKeyTotalSalesData = dateLabels.map(date => (nonSearch[date] ? nonSearch[date].keyTotalSales : 0));
+
+    // 광고비 데이터 생성
+    const searchAdCostData = dateLabels.map(date => (search[date] ? search[date].keyAdcost : 0));
+    const nonSearchAdCostData = dateLabels.map(date => (nonSearch[date] ? nonSearch[date].keyAdcost : 0));
+
+    // cvr 데이터 생성
+    const searchCvrData = dateLabels.map((date, index) => {
+        const keyClicks = searchImpressionData[index];
+        // console.log(impressions);
+        const adSales = searchKeyTotalSalesData[index];
+        // console.log(adSales);
+        return keyClicks > 0 ? (adSales / keyClicks) * 100 : 0; // 퍼센트로 표현
+    });
+    const nonsearchCvrData = dateLabels.map((date, index) => {
+        const keyClicks = nonsearchImpressionData[index];
+        // console.log(impressions);
+        const adSales = nonsearchKeyTotalSalesData[index];
+        console.log(adSales);
+        return keyClicks > 0 ? (adSales / keyClicks) * 100 : 0; // 퍼센트로 표현
+    });
+
+
+
+    const data = {
+        labels: dateLabels,
+        datasets: [
+            {
+                label: '검색 광고비',
+                data: searchAdCostData,
+                backgroundColor: 'rgba(54, 162, 235, 0.6)', // Search 색상 (파랑)
+                stack: 'Stack 0', // 스택 설정
+                order: 1, // 막대 그래프 우선
+            },
+            {
+                label: '비검색 광고비',
+                data: nonSearchAdCostData,
+                backgroundColor: 'rgba(255, 159, 64, 0.6)', // Non-Search 색상 (주황)
+                stack: 'Stack 0', // 스택 설정
+                order: 1, // 막대 그래프 우선
+            },
+            {
+                label: '검색 전환율',
+                data: searchCvrData,
+                borderColor: 'rgb(255, 99, 132)', // 전환율 선 색상 (빨강)
+                backgroundColor: 'rgba(255, 99, 132, 0.3)', // 전환율 색상 (옅은 빨강)
+                type: 'line', // 선 그래프로 표시
+                fill: false, // 선 그래프 안 채우기
+                yAxisID: 'y-cvr', // CVR 데이터의 y축 ID
+                order: 2, // CVR 선 그래프를 막대 위에 표시
+            },
+            {
+                label: '비검색 전환율',
+                data: nonsearchCvrData,
+                borderColor: 'rgb(0, 123, 255)', // Ad Cost 선 색상 (짙은 파랑)
+                backgroundColor: 'rgba(0, 123, 255, 0.3)', // Ad Cost 색상 (옅은 파랑)
+                type: 'line', // 선 그래프로 표시
+                fill: false, // 선 그래프 안 채우기
+                yAxisID: 'y-cvr', // CVR 데이터의 y축 ID
+                order: 2, // CVR 선 그래프를 막대 위에 표시
+            },
+        ],
+    };
+
+    // 옵션 설정
+    const options = {
+        responsive: true,
+        maintainAspectRatio: false, // 비율 유지하지 않음
+        plugins: {
+            legend: {
+                position: 'top',
+            },
+            title: {
+                display: true,
+                text: '광고비 및 전환율 그래프',
+            },
+        },
+        scales: {
+            x: {
+                title: {
+                    display: false,
+                    text: 'Date',
+                },
+            },
+            y: {
+                title: {
+                    display: true,
+                    text: '광고비',
+                },
+                stacked: true, // y 축 스택 설정
+                min: 0, // 최소값 설정
+                max: Math.max(...searchAdCostData, ...nonSearchAdCostData) * 1.5, // 최대값 설정 (최대 데이터의 1.5배)
+            },
+            'y-cvr': {
+                title: {
+                    display: true,
+                    text: '전환율 (%)',
+                },
+                position: 'right', // y축 위치 설정
+                ticks: {
+                    beginAtZero: true,
+                    max: 100, // CVR 최대값 설정
+                },
+                grid: {
+                    display: false, // Y축의 그리드 선을 보이지 않게 설정
+                },
+            },
+        },
+    };
+
+    return (
+        <div style={{ height: '100%' }}> {/* 부모의 높이에 맞추기 위해 100% 설정 */}
+            <Bar data={data} options={{ ...options, maintainAspectRatio: false }} /> {/* 비율 유지하지 않음 */}
+        </div>
+    );
+};
+
+export default StatGraph2;

--- a/src/components/CampaignStatistics/StatGraph2.jsx
+++ b/src/components/CampaignStatistics/StatGraph2.jsx
@@ -38,7 +38,7 @@ const StatGraph2 = ({ search, nonSearch, startDate, endDate }) => {
         const keyClicks = nonsearchImpressionData[index];
         // console.log(impressions);
         const adSales = nonsearchKeyTotalSalesData[index];
-        console.log(adSales);
+        // console.log(adSales);
         return keyClicks > 0 ? (adSales / keyClicks) * 100 : 0; // 퍼센트로 표현
     });
 
@@ -61,26 +61,6 @@ const StatGraph2 = ({ search, nonSearch, startDate, endDate }) => {
                 stack: 'Stack 0', // 스택 설정
                 order: 1, // 막대 그래프 우선
             },
-            {
-                label: '검색 전환율',
-                data: searchCvrData,
-                borderColor: 'rgb(255, 99, 132)', // 전환율 선 색상 (빨강)
-                backgroundColor: 'rgba(255, 99, 132, 0.3)', // 전환율 색상 (옅은 빨강)
-                type: 'line', // 선 그래프로 표시
-                fill: false, // 선 그래프 안 채우기
-                yAxisID: 'y-cvr', // CVR 데이터의 y축 ID
-                order: 2, // CVR 선 그래프를 막대 위에 표시
-            },
-            {
-                label: '비검색 전환율',
-                data: nonsearchCvrData,
-                borderColor: 'rgb(0, 123, 255)', // Ad Cost 선 색상 (짙은 파랑)
-                backgroundColor: 'rgba(0, 123, 255, 0.3)', // Ad Cost 색상 (옅은 파랑)
-                type: 'line', // 선 그래프로 표시
-                fill: false, // 선 그래프 안 채우기
-                yAxisID: 'y-cvr', // CVR 데이터의 y축 ID
-                order: 2, // CVR 선 그래프를 막대 위에 표시
-            },
         ],
     };
 
@@ -94,7 +74,7 @@ const StatGraph2 = ({ search, nonSearch, startDate, endDate }) => {
             },
             title: {
                 display: true,
-                text: '광고비 및 전환율 그래프',
+                text: '광고비 그래프',
             },
         },
         scales: {
@@ -112,20 +92,6 @@ const StatGraph2 = ({ search, nonSearch, startDate, endDate }) => {
                 stacked: true, // y 축 스택 설정
                 min: 0, // 최소값 설정
                 max: Math.max(...searchAdCostData, ...nonSearchAdCostData) * 1.5, // 최대값 설정 (최대 데이터의 1.5배)
-            },
-            'y-cvr': {
-                title: {
-                    display: true,
-                    text: '전환율 (%)',
-                },
-                position: 'right', // y축 위치 설정
-                ticks: {
-                    beginAtZero: true,
-                    max: 100, // CVR 최대값 설정
-                },
-                grid: {
-                    display: false, // Y축의 그리드 선을 보이지 않게 설정
-                },
             },
         },
     };

--- a/src/components/CampaignStatistics/StatGraph3.jsx
+++ b/src/components/CampaignStatistics/StatGraph3.jsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, LineElement } from 'chart.js';
+
+// Chart.js 등록
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, LineElement);
+
+const StatGraph3 = ({ search, nonSearch, startDate, endDate }) => {
+    // 날짜 배열 생성
+    const dateLabels = [];
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+
+    // 날짜 추가
+    for (let dt = start; dt <= end; dt.setDate(dt.getDate() + 1)) {
+        dateLabels.push(dt.toISOString().split('T')[0]); // 'YYYY-MM-DD' 형식으로 변환
+    }
+
+    // search와 nonSearch 데이터를 각각의 배열로 변환
+    const searchClicks = dateLabels.map(date => (search[date] ? search[date].keyClicks : 0));
+    const searchSales = dateLabels.map(date => (search[date] ? search[date].keyTotalSales : 0));
+    const nonSearchClicks = dateLabels.map(date => (nonSearch[date] ? nonSearch[date].keyClicks : 0));
+    const nonSearchSales = dateLabels.map(date => (nonSearch[date] ? nonSearch[date].keyTotalSales : 0));
+    const searchImpressions = dateLabels.map(date => (search[date] ? search[date].keyImpressions : 0));
+    const nonSearchImpressions = dateLabels.map(date => (nonSearch[date] ? nonSearch[date].keyImpressions : 0));
+
+    // CVR 데이터 생성
+    const searchCvrData = dateLabels.map((date, index) => {
+        const clicks = searchClicks[index];
+        const sales = searchSales[index];
+        return clicks > 0 ? (sales / clicks) * 100 : 0; // 퍼센트로 표현
+    });
+    const nonSearchCvrData = dateLabels.map((date, index) => {
+        const clicks = nonSearchClicks[index];
+        const sales = nonSearchSales[index];
+        return clicks > 0 ? (sales / clicks) * 100 : 0; // 퍼센트로 표현
+    });
+
+    // 클릭률 데이터 생성
+    const searchClickRate = dateLabels.map((date, index) => {
+        const clicks = searchClicks[index];
+        const impressions = searchImpressions[index];
+        return impressions > 0 ? (clicks / impressions) * 100 : 0; // 퍼센트로 표현
+    });
+    const nonSearchClickRate = dateLabels.map((date, index) => {
+        const clicks = nonSearchClicks[index];
+        const impressions = nonSearchImpressions[index];
+        return impressions > 0 ? (clicks / impressions) * 100 : 0; // 퍼센트로 표현
+    });
+
+    const data = {
+        labels: dateLabels,
+        datasets: [
+            {
+                label: '검색 전환율',
+                data: searchCvrData,
+                borderColor: 'rgb(255, 99, 132)', // 전환율 선 색상 (빨강)
+                backgroundColor: 'rgba(255, 99, 132, 0.3)', // 전환율 색상 (옅은 빨강)
+                type: 'line', // 선 그래프로 표시
+                fill: false, // 선 그래프 안 채우기
+                yAxisID: 'y', // 첫 번째 Y축
+                order: 1,
+            },
+            {
+                label: '비검색 전환율',
+                data: nonSearchCvrData,
+                borderColor: 'rgb(0, 123, 255)', // 비검색 전환율 선 색상 (짙은 파랑)
+                backgroundColor: 'rgba(0, 123, 255, 0.3)', // 비검색 전환율 색상 (옅은 파랑)
+                type: 'line', // 선 그래프로 표시
+                fill: false,
+                yAxisID: 'y', // 첫 번째 Y축
+                order: 1,
+            },
+            {
+                label: '검색 클릭률',
+                data: searchClickRate,
+                borderColor: 'rgb(0, 255, 0)', // 클릭률 선 색상 (초록)
+                backgroundColor: 'rgba(0, 255, 0, 0.3)', // 클릭률 색상 (옅은 초록)
+                type: 'line', // 선 그래프로 표시
+                fill: false,
+                yAxisID: 'y1', // 두 번째 Y축
+                order: 2,
+            },
+            {
+                label: '비검색 클릭률',
+                data: nonSearchClickRate,
+                borderColor: 'rgb(255, 165, 0)', // 클릭률 선 색상 (주황)
+                backgroundColor: 'rgba(255, 165, 0, 0.3)', // 클릭률 색상 (옅은 주황)
+                type: 'line', // 선 그래프로 표시
+                fill: false,
+                yAxisID: 'y1', // 두 번째 Y축
+                order: 2,
+            },
+        ],
+    };
+
+    // 옵션 설정
+    const options = {
+        responsive: true,
+        maintainAspectRatio: false, // 비율 유지하지 않음
+        plugins: {
+            legend: {
+                position: 'top',
+            },
+            title: {
+                display: true,
+                text: '전환율 및 클릭률 그래프',
+            },
+        },
+        scales: {
+            x: {
+                title: {
+                    display: false,
+                    text: 'Date',
+                },
+            },
+            y: {
+                title: {
+                    display: true,
+                    text: '전환율 (%)',
+                },
+                ticks: {
+                    beginAtZero: true,
+                    max: 100, // CVR 최대값 설정
+                },
+                grid: {
+                    display: false, // Y축의 그리드 선을 보이지 않게 설정
+                },
+            },
+            y1: {
+                position: 'right', // 두 번째 Y축 위치
+                title: {
+                    display: true,
+                    text: '클릭률 (%)',
+                },
+                ticks: {
+                    beginAtZero: true,
+                    max: 100, // 클릭률 최대값 설정
+                },
+                grid: {
+                    display: false, // 두 번째 Y축의 그리드 선을 보이지 않게 설정
+                },
+            },
+        },
+    };
+
+    return (
+        <div style={{ height: '100%' }}>
+            <Bar data={data} options={{ ...options, maintainAspectRatio: false }} />
+        </div>
+    );
+};
+
+export default StatGraph3;

--- a/src/components/CampaignStatistics/StatGraphTable.jsx
+++ b/src/components/CampaignStatistics/StatGraphTable.jsx
@@ -51,13 +51,21 @@ const StatGraphTable = ({ search, nonSearch, startDate, endDate }) => {
                 <table style={{ fontSize: '8px', width: '100%', borderCollapse: 'collapse' }}>
                     <thead>
                         <tr>
-                            <th></th>
+                            <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>날짜</td>
                             {dateLabels.map((date, index) => (
                                 <th key={index} style={{ padding: '5px', border: '1px solid #ddd' }}>{date}</th>
                             ))}
                         </tr>
                     </thead>
                     <tbody>
+                        {/* CVR Row */}
+                        <tr>
+                            <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>전환율 (%)</td>
+                            {cvrData.map((cvr, index) => (
+                                <td key={index} style={{ padding: '5px', border: '1px solid #ddd' }}>{cvr}</td>
+                            ))}
+                        </tr>
+
                         {/* Click Rate Row */}
                         <tr>
                             <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>클릭율 (%)</td>
@@ -84,17 +92,9 @@ const StatGraphTable = ({ search, nonSearch, startDate, endDate }) => {
                             ))}
                         </tr>
 
-                        {/* CVR Row */}
+                        {/* 광고전환판매수 */}
                         <tr>
-                            <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>전환율 (%)</td>
-                            {cvrData.map((cvr, index) => (
-                                <td key={index} style={{ padding: '5px', border: '1px solid #ddd' }}>{cvr}</td>
-                            ))}
-                        </tr>
-
-                        {/* Total Sales Row */}
-                        <tr>
-                            <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>Total Sales</td>
+                            <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>광고전환판매수</td>
                             {totalSalesData.map((sales, index) => (
                                 <td key={index} style={{ padding: '5px', border: '1px solid #ddd' }}>{sales}</td>
                             ))}

--- a/src/components/CampaignStatistics/StatGraphTable.jsx
+++ b/src/components/CampaignStatistics/StatGraphTable.jsx
@@ -53,7 +53,7 @@ const StatGraphTable = ({ search, nonSearch, startDate, endDate }) => {
                         <tr>
                             <td className="sticky-cell" style={{ padding: '5px', border: '1px solid #ddd' }}>날짜</td>
                             {dateLabels.map((date, index) => (
-                                <th key={index} style={{ padding: '5px', border: '1px solid #ddd' }}>{date}</th>
+                                <th key={index} style={{ padding: '5px', border: '1px solid #ddd', whiteSpace: 'nowrap' }}>{date.slice(5)}</th>
                             ))}
                         </tr>
                     </thead>

--- a/src/components/CampaignStatistics/StatisticGrid.jsx
+++ b/src/components/CampaignStatistics/StatisticGrid.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import StatTable from "./StatTable";
 import StatGraph from "./StatGraph";
 import StatGraphTable from "./StatGraphTable";
+import StatGraph2 from "./StatGraph2";
 import { getCampaignStats } from "../../services/keyword";
 import "../../styles/campaignStats/StatisticGrid.css";
 
@@ -78,6 +79,14 @@ const StatisticGrid = ({ campaignId, startDate, endDate }) => {
             </div>
             <div className="grid-item">
                 <StatGraphTable
+                    search={searchStats}
+                    nonSearch={nonSearchStats}
+                    startDate={startDate}
+                    endDate={endDate}
+                />
+            </div>
+            <div className="grid-item-graph"> {/*css 에서 height를 수정하여 세로 크기 조정 가능*/}
+                <StatGraph2
                     search={searchStats}
                     nonSearch={nonSearchStats}
                     startDate={startDate}

--- a/src/components/CampaignStatistics/StatisticGrid.jsx
+++ b/src/components/CampaignStatistics/StatisticGrid.jsx
@@ -3,6 +3,7 @@ import StatTable from "./StatTable";
 import StatGraph from "./StatGraph";
 import StatGraphTable from "./StatGraphTable";
 import StatGraph2 from "./StatGraph2";
+import StatGraph3 from "./StatGraph3";
 import { getCampaignStats } from "../../services/keyword";
 import "../../styles/campaignStats/StatisticGrid.css";
 
@@ -87,6 +88,14 @@ const StatisticGrid = ({ campaignId, startDate, endDate }) => {
             </div>
             <div className="grid-item-graph"> {/*css 에서 height를 수정하여 세로 크기 조정 가능*/}
                 <StatGraph2
+                    search={searchStats}
+                    nonSearch={nonSearchStats}
+                    startDate={startDate}
+                    endDate={endDate}
+                />
+            </div>
+            <div className="grid-item-graph"> {/*css 에서 height를 수정하여 세로 크기 조정 가능*/}
+                <StatGraph3
                     search={searchStats}
                     nonSearch={nonSearchStats}
                     startDate={startDate}

--- a/src/components/KeywordComponent.jsx
+++ b/src/components/KeywordComponent.jsx
@@ -140,7 +140,7 @@ const KeywordComponent = ({ campaignId, startDate, endDate, selectedKeywords, se
                                 >
                                     🔍
                                 </button>} {/* 돋보기 아이콘 추가 */}
-                                {item.keyBidFlag && <span className="badge">Bid</span>} {/* 마진 추가로 간격 조정 */}
+                                {item.keyBidFlag && <span className="badge">수동</span>} {/* 마진 추가로 간격 조정 */}
                             </td>
                             <td style={{
                                 color: item.keyExcludeFlag ? '#d3264f' : 'inherit',

--- a/src/components/Totalsearchbar.jsx
+++ b/src/components/Totalsearchbar.jsx
@@ -9,9 +9,15 @@ import { useParams } from "react-router-dom";
 
 const Totalsearchbar = ({ title }) => {
     const [activeTab, setActiveTab] = useState("stats");
-    const [startDate, setStartDate] = useState(new Date());
     const { campaignId } = useParams();
-    const [endDate, setEndDate] = useState(new Date());
+    const today = new Date();
+    const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    const lastDayOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+    firstDayOfMonth.setHours(12, 0, 0, 0);
+    lastDayOfMonth.setHours(23, 59, 59, 999);
+    // 초기값을 이번달로 설정
+    const [startDate, setStartDate] = useState(firstDayOfMonth);
+    const [endDate, setEndDate] = useState(lastDayOfMonth);
 
     const handleTabChange = (tabName) => {
         setActiveTab(tabName);
@@ -46,6 +52,17 @@ const Totalsearchbar = ({ title }) => {
                 setStartDate(last1Month);
                 setEndDate(yesterday);
                 break;
+            case "thismonth":
+                const today = new Date();
+                const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+                const lastDayOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+                firstDayOfMonth.setHours(12, 0, 0, 0);
+                lastDayOfMonth.setHours(23, 59, 59, 999);
+                // console.log(firstDayOfMonth);
+                // console.log(lastDayOfMonth);
+                setStartDate(firstDayOfMonth);
+                setEndDate(lastDayOfMonth);
+                break;
             default:
                 setStartDate(yesterday);
                 setEndDate(yesterday);
@@ -55,6 +72,7 @@ const Totalsearchbar = ({ title }) => {
 
     const handleStartDateChange = (date) => {
         if (date) {
+            // console.log(date);
             setStartDate(date);
             const endDate = new Date(date);
             endDate.setMonth(endDate.getMonth() + 1); // 시작일에서 1개월 추가
@@ -101,6 +119,7 @@ const Totalsearchbar = ({ title }) => {
                         className="dropdown"
                         onChange={(e) => handleDateRangeChange(e.target.value)}
                     >
+                        <option value="thismonth">이번 달</option>
                         <option value="yesterday">어제</option>
                         <option value="last7days">최근 1주</option>
                         <option value="last14days">최근 2주</option>

--- a/src/styles/KeywordComponent.css
+++ b/src/styles/KeywordComponent.css
@@ -73,6 +73,7 @@ th svg {
     /* 패딩 없음 */
     transition: background-color 0.2s, transform 0.2s;
     /* 부드러운 효과 */
+    margin-left: 5px;
 }
 
 .icon-button:hover {

--- a/src/styles/TabComponent.css
+++ b/src/styles/TabComponent.css
@@ -68,12 +68,12 @@
 
 /* 우측 활성화 탭 */
 .tab.active.right {
-    border-radius: 0 50px 0 0;
+    border-radius: 16px 50px 0 0;
 }
 
 /* 중간 활성화 탭 */
 .tab.active.middle {
-    border-radius: 50px 50px 0 0;
+    border-radius: 16px 50px 0 0;
 }
 
 /* 콘텐츠 영역 */
@@ -121,15 +121,16 @@
     align-items: center;
     background-color: #D6DBF2;
     border-radius: 20px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    /* box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); */
 }
 
 .dropdown {
     padding: 8px 12px;
     border: 1px solid #ddd;
-    border-radius: 8px;
+    border-radius: 20px;
     background-color: #D6DBF2;
     font-size: 14px;
     cursor: pointer;
     color: #4C547B;
+    margin-right: 5px;
 }


### PR DESCRIPTION
1. 광고비 및 전환율 관련 그래프 추가.
![image](https://github.com/user-attachments/assets/d6037996-4f64-4abc-bf33-4c7137e7e2fb)

2. 캠패인 통계 탭에 table th 순서 수정 및 "날짜" 추가.
![image](https://github.com/user-attachments/assets/c6fe3414-1368-41ea-8b88-27a0a3384670)


3. 뱃지 이름 변경 및 마진 추가
![image](https://github.com/user-attachments/assets/395af0de-24c5-46e1-8114-c08e122c26b9)

4. 그래프에서 선 그래프가 막대 그래프 위에 오도록 수정.
![image](https://github.com/user-attachments/assets/0312af01-0a45-462a-9734-66db612f690e)

 