### PR TITLE
Fix/margin 0327

### DIFF
--- a/src/components/GoogleLoginButton.jsx
+++ b/src/components/GoogleLoginButton.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import Button from "./Button";
-
+import { EXCEPT_API_URL } from '../config/api';
 const GoogleLoginButton = () => {
     const handleLogin = () => {
         console.log("구글 로그인 호출")
-        window.location.href = `https://server.grouup.co.kr/oauth2/authorization/google`;
+        window.location.href = `${EXCEPT_API_URL}/oauth2/authorization/google`;
     };
 
     return (

--- a/src/components/KakaoLoginButton.jsx
+++ b/src/components/KakaoLoginButton.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Button from "./Button";
-
+import { EXCEPT_API_URL } from "../config/api";
 // 환경 변수에서 REST API 키와 리다이렉트 URI 가져오기
 const REST_API_KEY = process.env.REACT_APP_REST_API_KEY;
 
@@ -9,7 +9,7 @@ const KakaoLoginButton = () => {
         console.log('REST_API_KEY:', REST_API_KEY);
 
         // 카카오 로그인 페이지로 리다이렉트
-        window.location.href = `https://server.grouup.co.kr/oauth2/authorization/kakao`;
+        window.location.href = `${EXCEPT_API_URL}/oauth2/authorization/kakao`;
     };
 
     return (

--- a/src/components/Margin/MarginCalculatorResult.jsx
+++ b/src/components/Margin/MarginCalculatorResult.jsx
@@ -47,7 +47,6 @@ const MarginCalculatorResult = ({ campaigns, startDate, endDate }) => {
             if (typeof changedData !== 'object' || Array.isArray(changedData)) {
                 throw new Error("변경된 데이터의 형식이 올바르지 않습니다.");
             }
-
             const data = {
                 campaignId: selectedCampaign.campaignId,
                 data: Object.values(changedData).map(item => ({
@@ -57,9 +56,12 @@ const MarginCalculatorResult = ({ campaigns, startDate, endDate }) => {
                     marAdBudget: item.marAdBudget // 광고예산
                 })),
             };
-            console.log(data)
+            if (data.data.length == 0) {
+                alert("바뀐 데이터가 없습니다.")
+                return
+            }
             const response = await updateEfficiencyAndAdBudget(data);
-
+            console.log(response)
             alert("저장되었습니다.");
         } catch (error) {
             console.error("저장 중 오류 발생:", error);
@@ -89,19 +91,26 @@ const MarginCalculatorResult = ({ campaigns, startDate, endDate }) => {
                             onClick={() => toggleExpandCampaign(campaign.campaignId)}
                         >
                             <h3>{campaign.title}</h3>
-                            <div className="button-container"> {/* 버튼을 감싸는 컨테이너 추가 */}
+                            <div className="button-container">
                                 <button
                                     className="add-button"
-                                    onClick={() => handleSave(campaign)}>
+                                    onClick={(e) => {
+                                        e.stopPropagation(); // 이벤트 버블링 막기
+                                        handleSave(campaign);
+                                    }}>
                                     목표효율/예산 저장
                                 </button>
                                 <button
                                     className="add-button"
-                                    onClick={() => handleOptionMarginClick(campaign)}>
+                                    onClick={(e) => {
+                                        e.stopPropagation(); // 이벤트 버블링 막기
+                                        handleOptionMarginClick(campaign);
+                                    }}>
                                     기간별 원가 수정
                                 </button>
                             </div>
                         </div>
+
                         {expandedCampaignId.has(campaign.campaignId) && (
                             <CampaignDataTable
                                 data={tableData.find(item => item.campaignId === campaign.campaignId)?.data || []}

--- a/src/components/Margin/MarginCalculatorResult.jsx
+++ b/src/components/Margin/MarginCalculatorResult.jsx
@@ -61,7 +61,6 @@ const MarginCalculatorResult = ({ campaigns, startDate, endDate }) => {
                 return
             }
             const response = await updateEfficiencyAndAdBudget(data);
-            console.log(response)
             alert("저장되었습니다.");
         } catch (error) {
             console.error("저장 중 오류 발생:", error);

--- a/src/components/Margin/MarginDataTable.jsx
+++ b/src/components/Margin/MarginDataTable.jsx
@@ -47,6 +47,7 @@ const MarginDataTable = ({ startDate, endDate, campaignId, onDataChange }) => {
         { optionName: "광고 전환 판매 수", key: "marAdConversionSales" },
         { optionName: "실제 판매 수", key: "marActualSales" },
         { optionName: "반품 개수", key: "marReturnCount" },
+        { optionName: "반품 비용", key: "marReturnCost" },
         { optionName: "광고 마진", key: "marAdMargin" },
         { optionName: "순이익", key: "marNetProfit" },
     ];
@@ -110,7 +111,6 @@ const MarginDataTable = ({ startDate, endDate, campaignId, onDataChange }) => {
 
                                 if (itemForDate) {
                                     if (option.key === "marAdRevenue") {
-                                        console.log("수웅", itemForDate.marAdMargin, itemForDate.marAdCost)
                                         value = itemForDate.marAdCost > 0
                                             ? ((itemForDate.marAdMargin / itemForDate.marAdCost) * 100).toFixed(2) + '%'
                                             : '0.00%';
@@ -134,7 +134,10 @@ const MarginDataTable = ({ startDate, endDate, campaignId, onDataChange }) => {
                                         value = formatNumber(itemForDate.marAdMargin);
                                     } else if (option.key === "marNetProfit") {
                                         value = formatNumber(Math.round(itemForDate.marNetProfit));
-                                    } else {
+                                    } else if (option.key === "marReturnCost") {
+                                        value = formatNumber(Math.round(itemForDate.marReturnCost));
+                                    }
+                                    else {
                                         value = itemForDate[option.key] || '-';
                                     }
                                 }
@@ -191,7 +194,7 @@ const MarginDataTable = ({ startDate, endDate, campaignId, onDataChange }) => {
                                 ) : (
                                     formatNumber(
                                         Math.floor(data.reduce((total, item) => {
-                                            if (["marAdCost", "marImpressions", "marActualSales", "marReturnCount", "marAdMargin", "marNetProfit", "marAdConversionSales"].includes(option.key)) {
+                                            if (["marAdCost", "marImpressions", "marActualSales", "marReturnCount", "marAdMargin", "marNetProfit", "marAdConversionSales", "marReturnCost"].includes(option.key)) {
                                                 return total + (item[option.key] || 0);
                                             }
                                             return total;

--- a/src/components/Margin/MarginDataTable.jsx
+++ b/src/components/Margin/MarginDataTable.jsx
@@ -83,10 +83,12 @@ const MarginDataTable = ({ startDate, endDate, campaignId, onDataChange }) => {
                 [fullDate]: updatedData // 전체 업데이트된 데이터 반환
             };
         });
-
-        // 부모 컴포넌트에 변경된 데이터 전달
-        onDataChange(modifiedData);
     };
+
+    useEffect(() => {
+        onDataChange(modifiedData);
+    }, [modifiedData]);
+
 
 
     return (

--- a/src/components/Margin/MarginResultModal.jsx
+++ b/src/components/Margin/MarginResultModal.jsx
@@ -106,6 +106,7 @@ const MarginResultModal = ({ isOpen, onClose, campaignId }) => {
                 mfcCostPrice: updatedOptions[index].mfcCostPrice,
                 mfcPerPiece: updatedOptions[index].mfcPerPiece,
                 mfcZeroRoas: updatedOptions[index].mfcZeroRoas,
+                mfcType: updatedOptions[index].mfcType
             })),
         };
 

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1,1 +1,3 @@
-export const API_URL = process.env.REACT_APP_API_URL || 'https://server.grouup.co.kr/api';
+export const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8080/api';
+export const EXCEPT_API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8080';
+export const PYTHON_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';

--- a/src/services/margin.js
+++ b/src/services/margin.js
@@ -42,9 +42,9 @@ export const getDailyMarginSummary = async ({ date }) => {
         throw error
     }
 }
-export const getNetProfit = async ({ startDate, endDate, }) => {
+export const getNetProfitAndReturnCost = async ({ startDate, endDate, }) => {
     try {
-        const response = await apiRequest(`/margin/getNetProfit?startDate=${startDate}&endDate=${endDate}`);
+        const response = await apiRequest(`/margin/getNetProfitAndReturnCost?startDate=${startDate}&endDate=${endDate}`);
         return response;
     } catch (error) {
         throw error
@@ -52,11 +52,10 @@ export const getNetProfit = async ({ startDate, endDate, }) => {
 }
 export const updateEfficiencyAndAdBudget = async (data) => {
     try {
-        const response = await apiRequest('/margin/updateEfficiencyAndAdBudget', 'POST', data);
+        const response = await apiRequest(`/margin/updateEfficiencyAndAdBudget`, 'POST', data);
         return response; // 성공 시 반환
     } catch (error) {
         console.error('데이터 생성 중 오류 발생:', error.message);
         throw error; // 오류를 상위로 전달
     }
 };
-

--- a/src/services/pythonapi.js
+++ b/src/services/pythonapi.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { getToken } from '../utils/tokenManager';  // 토큰 가져오기 함수 사용
-
+import { PYTHON_URL } from '../config/api';
 export const uploadFile1 = (file, onUploadProgress) => {
   console.log(1)
   console.log(file)
@@ -10,7 +10,7 @@ export const uploadFile1 = (file, onUploadProgress) => {
   // 토큰 가져오기
   const token = getToken();
 
-  return axios.post('https://server.grouup.co.kr/django/upload_excel/', formData, {
+  return axios.post(`${PYTHON_URL}django/upload_excel/`, formData, {
     headers: {
       'Content-Type': 'multipart/form-data',
       'Authorization': `Bearer ${token}`  // Authorization 헤더에 토큰 추가
@@ -42,7 +42,7 @@ export const uploadFile3 = (file, onUploadProgress) => {
   // 토큰 가져오기
   const token = getToken();
 
-  return axios.post('https://server.grouup.co.kr/django/upload_margin/', formData, {
+  return axios.post(`${PYTHON_URL}django/upload_margin/`, formData, {
     headers: {
       'Content-Type': 'multipart/form-data',
       'Authorization': `Bearer ${token}`  // Authorization 헤더에 토큰 추가

--- a/src/styles/MarginCalculatorForm.css
+++ b/src/styles/MarginCalculatorForm.css
@@ -12,11 +12,25 @@
 
 .campaign-header {
     display: flex;
-    align-items: center;
     justify-content: space-between;
-    margin-left: 2%;
-    margin-right: 1%;
-    gap: 10px;
+    /* 제목과 버튼들을 양쪽 끝으로 보냅니다. */
+    align-items: center;
+    /* 세로 중앙 정렬 */
+}
+
+.campaign-header {
+    display: flex;
+    justify-content: space-between;
+    /* 제목과 버튼들을 양쪽 끝으로 보냅니다. */
+    align-items: center;
+    /* 세로 중앙 정렬 */
+}
+
+.button-container {
+    display: flex;
+    /* 버튼들을 가로로 나열합니다. */
+    gap: 8px;
+    /* 버튼 사이 간격 */
 }
 
 .campaign-header h3 {


### PR DESCRIPTION
1. 목표효율/ 예상 저장을 누르면 카드 클릭으로 인식하여 닫힙니다. 
2. 기간별 원가 수정에 로켓인지, 판매자 타입인지 나타내줍니다. 
3. 마진 결과보기에 반품비와, 반품비용, 총 반품비용, 총 반품 갯수를 보여줍니다. 
- 스프링 코드 완료
4. 목표효율/예산 저장 누르면 맨 마지막 값이 1개 빠지는 현상
- useEffect 로 변할때 상위 컴포넌트에 전달합니다.
- 기존은 전달을 먼저하고, 데이터를 채워 맨 마지막값이 채워지지 않았습니다.
 

![스크린샷 2025-04-01 오후 12 19 11](https://github.com/user-attachments/assets/355c61d1-bf0a-4e50-b67d-34d7222a89f9)
![스크린샷 2025-04-01 오후 12 11 33](https://github.com/user-attachments/assets/3d16e374-6bd0-44e8-8930-4eb49950eaa7)
![스크린샷 2025-04-01 오후 12 12 26](https://github.com/user-attachments/assets/a605fdc7-8937-430c-ab29-8dbe2a4875dc)
