### PR TITLE
Refacotr : 수동입찰가 복사 버튼, 액셀 다운로드로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.1",
         "react-scripts": "^5.0.1",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@types/react-datepicker": "^6.2.0",
@@ -4530,6 +4531,15 @@
         "node": ">=8.9"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -5497,6 +5507,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5730,6 +5753,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -5939,6 +5971,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -8208,6 +8252,15 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -14462,6 +14515,18 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -16274,6 +16339,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -16645,6 +16728,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.1",
     "react-scripts": "^5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "xlsx": "^0.18.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/KeyTotalComponent.jsx
+++ b/src/components/KeyTotalComponent.jsx
@@ -229,34 +229,32 @@ const KeytotalComponent = ({ campaignId, startDate, endDate }) => {
         }
 
         try {
+            // --- URL에서 title 파라미터 추출 시작 ---
+            const urlParams = new URLSearchParams(window.location.search); // 현재 URL의 쿼리 문자열 파싱
+            const titleParam = urlParams.get('title'); // 'title' 파라미터 값 가져오기 (예: '방한마스크')
+
+            // title 파라미터 값이 있으면 사용하고, 없으면 기본값 '키워드' 사용
+            const baseFilename = titleParam ? titleParam : '키워드';
+            // 최종 파일 이름 조합 (예: "방한마스크_수동입찰가.xlsx")
+            const filename = `${baseFilename}_수동입찰가.xlsx`;
+            // --- URL에서 title 파라미터 추출 끝 ---
+
+
             // 1. SheetJS를 위한 데이터 준비 (배열의 배열 형식)
-            //    첫 번째 행은 헤더(제목), 그 다음 행부터 데이터입니다.
             const header = ['키워드', '입찰가']; // 엑셀 열 제목 정의
             const dataToExport = bidKeywords.map(keyword => [
                 keyword.keyKeyword,
                 keyword.bid
             ]);
-
-            // 헤더와 데이터를 합칩니다.
-            const worksheetData = [header, ...dataToExport];
+            const worksheetData = [header, ...dataToExport]; // 헤더와 데이터 결합
 
             // 2. 새 워크북을 만들고 워크시트를 추가합니다.
             const wb = XLSX.utils.book_new(); // 새 워크북 생성
             const ws = XLSX.utils.aoa_to_sheet(worksheetData); // 배열 데이터로부터 워크시트 생성
-
-            // 선택사항: 열 너비 조정 (예: 첫 번째 열 너비 설정)
-            // ws['!cols'] = [{ wch: 30 }, { wch: 15 }]; // 첫 2개 열 너비 설정
-
             XLSX.utils.book_append_sheet(wb, ws, '수동 입찰가'); // 워크북에 워크시트 추가, 시트 이름은 '수동 입찰가'
 
-            // 3. 다운로드될 파일 이름 정의
-            const filename = '수동 입찰가 키워드.xlsx'; // 다운로드될 엑셀 파일 이름
-
-            // 4. 엑셀 파일을 생성하고 다운로드를 시작합니다.
+            // 3. 엑셀 파일을 생성하고 다운로드를 시작합니다. (파일 이름은 위에서 동적으로 생성됨)
             XLSX.writeFile(wb, filename);
-
-            // 다운로드 성공 알림 (선택 사항)
-            // alert("엑셀 파일 다운로드가 시작됩니다.");
 
         } catch (error) {
             // 오류 발생 시 콘솔에 로그를 남기고 사용자에게 알림

--- a/src/styles/KeywordComponent.css
+++ b/src/styles/KeywordComponent.css
@@ -84,3 +84,29 @@ th svg {
     transform: scale(1.1);
     /* 마우스 오버 시 확대 */
 }
+
+.keyword-table {
+    max-height: 600px;
+    /* 예시: 테이블의 최대 높이를 지정해야 스크롤이 생깁니다. */
+    overflow-y: auto;
+    /* 세로 스크롤을 활성화합니다. */
+    position: relative;
+    /* 일부 브라우저/상황에서 sticky 기준점으로 필요할 수 있습니다. */
+    margin-top: 5px;
+}
+
+/* thead 안의 모든 th 요소에 sticky 속성 적용 */
+.keyword-table thead th {
+    position: sticky;
+    top: 0;
+    /* 스크롤 컨테이너(.keyword-table)의 상단에 고정 */
+    background-color: rgba(152, 179, 248, 0.993);
+    /* 중요: 스크롤되는 내용이 비치지 않도록 배경색 지정 */
+    /* z-index: 10;
+    다른 요소 위에 표시되도록 z-index 설정 (필요에 따라 조정) */
+    padding: 12px 8px;
+    /* text-align: center; */
+    /* 예시 정렬 */
+    font-weight: bold;
+    /* 예시 폰트 두께 */
+}


### PR DESCRIPTION
1. 복사 버튼을 액셀로 다운로드 기능으로 변경하였습니다.

"캠패인명_수동입찰가" 라는 이름으로 액셀이 다운로드.

![image](https://github.com/user-attachments/assets/01dc4ef7-c67d-463b-bbfb-e342886d5a52)

2. 키워드 테이블 헤더를 고정하였습니다.

다만, 헤더를 고정하기 위해서는 테이블에 사이즈를 설정해줘야 했습니다.

![image](https://github.com/user-attachments/assets/c4b9acbc-f47e-46d6-83e3-f6455517a194)

그로 인해 옆에 스크롤이 하나 생겼습니다.

연한 색으로 헤더를 칠하면 td가 아래에 보여서 일단 임시로 색을 칠했습니다. 

모든 키워드 테이블 th에 적용됩니다.